### PR TITLE
Correct misspelling of some vulnerabilities (Heart Bleed -> Heartbleed, Eternal Blue -> EternalBlue)

### DIFF
--- a/src/chp1/_index.md
+++ b/src/chp1/_index.md
@@ -34,7 +34,7 @@ Memory-unsafe programs risk both outcomes, simultaneously.
 These incredible risks are largely mitigated[^AppLang] in most modern "application languages", which use garbage collection and/or heavyweight runtimes (think Python, Java, or Go).
 Yet there are key verticals - safety-critical systems, high-performance distributed infrastructure, various kinds of firmware, etc. - that continue to rely on C and C++[^CStory].
 
-Despite re-inventing themselves over time and powering much of the world's most critical software, these two traditional "systems languages" remain leading suppliers of worst-case security vulnerabilities (e.g. Heart Bleed[^HBleed], Stagefright[^StageFright], Eternal Blue[^EternalBlue], Dirty Pipe[^DirtyPipe], etc).
+Despite re-inventing themselves over time and powering much of the world's most critical software, these two traditional "systems languages" remain leading suppliers of worst-case security vulnerabilities (e.g. Heartbleed[^HBleed], Stagefright[^StageFright], EternalBlue[^EternalBlue], Dirty Pipe[^DirtyPipe], etc).
 The memory corruption threat remains unabated.
 
 Such is the cost of a multi-decade commitment to backwards compatibility.

--- a/src/chp1/about_the_team.md
+++ b/src/chp1/about_the_team.md
@@ -28,6 +28,7 @@ Listed alphabetically:
 * [duzumaki](https://github.com/duzumaki)
 * [jam1garner](https://github.com/jam1garner)
 * [kaylynn234](https://github.com/kaylynn234)
+* [LoganDark](https://github.com/LoganDark)
 * [Michcioperz](https://github.com/Michcioperz)
 * [rrevi](https://github.com/rrevi)
 


### PR DESCRIPTION
Fixes #6

Also adds me to the contributors list - the `CONTRIBUTING.md` encourages it, but this is a really small change so it feels weird.