### PR TITLE
Fixes some typos in chp2

### DIFF
--- a/src/chp2/dynamic_assurance_3.md
+++ b/src/chp2/dynamic_assurance_3.md
@@ -107,7 +107,7 @@ DEC 4096 HEX 1000:  ff 25 b5 89  95 99 67 07   e5 1f bd f0  8b 34 d8 75
 ```
 
 We're given a key (line 2) and 18 samples from the keystream a valid RC4 implementation should produce (the subsequent rows).
-Each sample is 16 byte long and preceded by its offset into the keystream (given in both decimal and hex).
+Each sample is 16 bytes long and preceded by its offset into the keystream (given in both decimal and hex).
 
 Translating every sample from every table into a test suite would be important for a real library, but tedious for our example.
 So we'll use just the first 4 rows of the table above:
@@ -156,7 +156,7 @@ Before we get to the fun and tangible part - writing a command line tool that us
 >
 > Because both performance and security are core requirements, cryptography is a prime use case for Rust (pun intended).
 > The language has a thriving cryptographic ecosystem.
-> `rustls`[^RusTLS], pure-Rust TLS library, is one notable project.
+> `rustls`[^RusTLS], a pure-Rust TLS library, is one notable project.
 > In 2019, it outperformed OpenSSL by significant margins[^FastRust].
 
 ---

--- a/src/chp2/static_assurance_1.md
+++ b/src/chp2/static_assurance_1.md
@@ -134,7 +134,7 @@ Since this might be your first glimpse of C, let's take a minute to break down w
 
     * `*a += *b;` is shorthand for `*a = *a + *b;`, a semicolon-terminated statement.
 
-    * Here, unlike in the signature, the `*` operator means "dereference the pointer", e.g. read the the value of it's target.
+    * Here, unlike in the signature, the `*` operator means "dereference the pointer", e.g. read the value of its target.
 
     * `*` takes precedence over `+`, meaning the read happens first. Precedence mistakes can be tricky with pointer arithmetic!
 

--- a/src/chp2/static_assurance_2.md
+++ b/src/chp2/static_assurance_2.md
@@ -48,7 +48,7 @@ fn incr(a: &mut isize, b: &isize) {
 }
 ```
 
-We broke down the C version down piece-by-piece, so you already know what this function does.
+We broke down the C version piece-by-piece, so you already know what this function does.
 Take a second to review the above.
 Can you make some guesses about the syntax?
 

--- a/src/chp2/static_assurance_2.md
+++ b/src/chp2/static_assurance_2.md
@@ -197,7 +197,7 @@ If Rust grants C-like control over memory, shouldn't the compiler's internal ana
 Perhaps surprisingly, no.
 Three related factors are at play:
 
-* **Type-system Support:** Rust's internal analyzers build upon a bedrock of direct integration with the language itself, in its type system, which implements a flavor of "affine types"[^AffineTypes] and doesn't permit arbitrary type casting.
+* **Type-system Support:** Rust's internal analyzers build upon a bedrock of direct integration with the language itself, in its type system. Which implements a flavor of "affine types"[^AffineTypes] and doesn't permit arbitrary type casting.
 
     * Performing static analysis on a weakly-typed language (like C) doesn't have comparable co-design advantages. The Rust compiler can prove properties no C-family compiler or analysis tool can prove, by design.
 

--- a/src/chp2/static_assurance_2.md
+++ b/src/chp2/static_assurance_2.md
@@ -197,7 +197,7 @@ If Rust grants C-like control over memory, shouldn't the compiler's internal ana
 Perhaps surprisingly, no.
 Three related factors are at play:
 
-* **Type-system Support:** Rust's internal analyzers build upon a bedrock of direct integration with the language itself, in its type system. Which implements a flavor of "affine types"[^AffineTypes] and doesn't permit arbitrary type casting.
+* **Type-system Support:** Rust's internal analyzers build upon a bedrock of direct integration with the language itself, in its type system, which implements a flavor of "affine types"[^AffineTypes] and doesn't permit arbitrary type casting.
 
     * Performing static analysis on a weakly-typed language (like C) doesn't have comparable co-design advantages. The Rust compiler can prove properties no C-family compiler or analysis tool can prove, by design.
 


### PR DESCRIPTION
Changes "e.g. read the the value of it's target." of line 137 of `static_asurance_1.md` to "e.g. read the value of its target."

Removes duplicate "down" of "We broke down the C version down" in `static_assurance_2.md`

Alters ". Which" to ", which" in `static_assurance_2.md` 

Minor grammatical fixes to `dynamic_assurance_3.md`