### PR TITLE
Fixes typo(s) in chp2

### DIFF
--- a/code_snippets/chp2/crypto_tool/rcli/src/main.rs
+++ b/code_snippets/chp2/crypto_tool/rcli/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> std::io::Result<()> {
         .collect::<Vec<u8>>();
 
     // Validation note:
-    // `Args` enforces (5 <= key_bytes.len() && key_bytes.len() <= 256)
+    // `Args` enforces (5 >= key_bytes.len() && key_bytes.len() <= 256)
 
     // Open the file for both reading and writing
     let mut file = File::options().read(true).write(true).open(&args.file)?;

--- a/code_snippets/chp2/crypto_tool/rcli/src/main.rs
+++ b/code_snippets/chp2/crypto_tool/rcli/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> std::io::Result<()> {
         .collect::<Vec<u8>>();
 
     // Validation note:
-    // `Args` enforces (5 >= key_bytes.len() && key_bytes.len() <= 256)
+    // `Args` enforces (5 <= key_bytes.len() && key_bytes.len() <= 256)
 
     // Open the file for both reading and writing
     let mut file = File::options().read(true).write(true).open(&args.file)?;

--- a/src/chp2/cli.md
+++ b/src/chp2/cli.md
@@ -98,7 +98,7 @@ fn main() {
 }
 ```
 
-* The `Args` has is a `struct` with 2 fields:
+* The `Args` is a `struct` with 2 fields:
 
     * `file`, a string that will contain the path/name of the file to be en/decrypted.
 

--- a/src/chp2/limits.md
+++ b/src/chp2/limits.md
@@ -58,7 +58,7 @@ Sometimes casting errors introduce *type confusion* vulnerabilities, where memor
 > **How does type confusion happen in C++?**
 >
 > Although C++ is statically typed, it remains a type-unsafe language.
-> On the extreme end, it's weak typing means programmers can cast between arbitrary types that have no logical relationship.
+> On the extreme end, its weak typing means programmers can cast between arbitrary types that have no logical relationship.
 >
 > More commonly, programmers cast between types within a given hierarchy of objects.
 > This makes logical sense in the context, but introduces potential for subtle errors.

--- a/src/chp2/limits.md
+++ b/src/chp2/limits.md
@@ -259,7 +259,7 @@ Systems we *consider* secure are typically those that have stood the test of tim
 Like well-studied protocols or heavily audited open-source projects.
 But a new vulnerability is always a possibility.
 
-Remember: this is *no absolute* security.
+Remember: there is *no absolute* security.
 Only levels of *assurance*.
 
 With all of this context out of the way, let's return to our RC4 library and leverage it for something useful: encrypting local files via a command line interface.


### PR DESCRIPTION
"`On the extreme end, it's weak typing means`"
to: 
"`On the extreme end, its weak typing means`"
(limits.md Line 61)

```
Remember: this is *no absolute* security.
Only levels of *assurance*.
```
to:
```
Remember: there is *no absolute* security.
Only levels of *assurance*.
```
(limits.md line 262)