### PR TITLE
Fixes spelling mistake

### DIFF
--- a/src/chp1/about_the_team.md
+++ b/src/chp1/about_the_team.md
@@ -42,6 +42,7 @@ Listed alphabetically:
 * [aelnona](https://github.com/aelnona)
 * [asher-gh](https://github.com/asher-gh)
 * [drlef](https://github.com/drlef)
+* [Druthyn](https://github.com/Druthyn)
 * [duzumaki](https://github.com/duzumaki)
 * [humb1t](https://github.com/humb1t)
 * [jam1garner](https://github.com/jam1garner)

--- a/src/chp3/rust_2_high_data_rep.md
+++ b/src/chp3/rust_2_high_data_rep.md
@@ -172,7 +172,7 @@ Note that named fields (`pid`, `state`, and `children`) are private by default.
 They can only be accessed by code in the *module* in which the struct is defined.
 Modules are a way to group related code, think of them as Rust's version of namespaces.
 
-If this code where in another module that imported `Proc`, it would not compile because the private field `state` cannot be assigned to:
+If this code were in another module that imported `Proc`, it would not compile because the private field `state` cannot be assigned to:
 
 ```rust,ignore
 use my_os_module::Proc;


### PR DESCRIPTION
Tiny PR to address a mistake I spotted whilst reading through the book.

Following CONTRIBUTING.md, I also added my name/profile link to the contributor list.