### PR TITLE
chp4: c_snippet: fix assert statement

### DIFF
--- a/code_snippets/chp4/c_snippets/spatial.c
+++ b/code_snippets/chp4/c_snippets/spatial.c
@@ -9,7 +9,7 @@ char* get_greeting() {
         return NULL;
     } else {
         strncpy(greeting, "Hello", 6);
-        assert(greeting[6] == '\0');
+        assert(greeting[5] == '\0');
         return greeting;
     }
 }

--- a/code_snippets/chp4/c_snippets/temporal.c
+++ b/code_snippets/chp4/c_snippets/temporal.c
@@ -9,7 +9,7 @@ char* get_greeting() {
         return NULL;
     } else {
         strncpy(greeting, "Hello", 6);
-        assert(greeting[6] == '\0');
+        assert(greeting[5] == '\0');
         return greeting;
     }
 }

--- a/src/chp1/about_the_team.md
+++ b/src/chp1/about_the_team.md
@@ -47,6 +47,7 @@ Listed alphabetically:
 * [humb1t](https://github.com/humb1t)
 * [jam1garner](https://github.com/jam1garner)
 * [jamesreprise](https://github.com/jamesreprise)
+* [jkoeppeler](https://github.com/jkoeppeler)
 * [kaylynn234](https://github.com/kaylynn234)
 * [LoganDark](https://github.com/LoganDark)
 * [Michcioperz](https://github.com/Michcioperz)

--- a/src/chp4/attack_1.md
+++ b/src/chp4/attack_1.md
@@ -102,7 +102,7 @@ char* get_greeting() {
         return NULL;
     } else {
         strncpy(greeting, "Hello", 6);
-        assert(greeting[6] == '\0');
+        assert(greeting[5] == '\0');
         return greeting;
     }
 }


### PR DESCRIPTION
The assert compares a wrong value to be the null-terminator. 6 bytes are allocated, so accessing index 6 is an out-of-bound read operation. The correct offset should be 5.