### PR TITLE
chp2: crypto_tool: fix assert statement

### DIFF
--- a/code_snippets/chp2/crypto_tool/rc4/src/lib.rs
+++ b/code_snippets/chp2/crypto_tool/rc4/src/lib.rs
@@ -15,7 +15,7 @@ impl Rc4 {
     /// Init a new Rc4 stream cipher instance
     pub fn new(key: &[u8]) -> Self {
         // Verify valid key length (40 to 2048 bits)
-        assert!(5 <= key.len() && key.len() <= 256);
+        assert!(5 >= key.len() && key.len() <= 256);
 
         // Zero-init our struct
         let mut rc4 = Rc4 {


### PR DESCRIPTION
The assert wrong valid the lower bound of key size range.