### PR TITLE
Update name in reference

### DIFF
--- a/src/chp1/_index.md
+++ b/src/chp1/_index.md
@@ -242,7 +242,7 @@ This book will help you quickly tame the high learning curve of Rust, so we can 
 
 ---
 
-[^RustTrust]: [*You Can't Spell Trust Without Rust*](https://gankra.github.io/blah/thesis.pdf). Alexis Beingessner (2015). This Master's thesis by one of the Rust standard library BTree authors is the source of this botnet analogy, and a general influence on this book.
+[^RustTrust]: [*You Can't Spell Trust Without Rust*](https://gankra.github.io/blah/thesis.pdf). Aria Desires (2015). This Master's thesis by one of the Rust standard library BTree authors is the source of this botnet analogy, and a general influence on this book.
 
 [^AppLang]: "Largely" is a caveat here: Python can have data races, Go can have segmentation faults, etc. But garbage collected languages don't give attackers the same powerful exploitation primitives as C and C++ (more details coming in Chapter 4), so they don't carry the same risks.
 

--- a/src/chp1/why_this_book.md
+++ b/src/chp1/why_this_book.md
@@ -259,6 +259,6 @@ It may not *be easy* - but it can *be*.
 
 [^PyList]: [*dictobject.c*](https://github.com/python/cpython/blob/master/Objects/dictobject.c). CPython Interpreter (2021).
 
-[^TooManyLink]: [*Learn Rust With Entirely Too Many Linked Lists*](https://rust-unofficial.github.io/too-many-lists/). Alexis Beingessner (2021).
+[^TooManyLink]: [*Learn Rust With Entirely Too Many Linked Lists*](https://rust-unofficial.github.io/too-many-lists/). Aria Desires (2021).
 
 [^Moore]: [*Moore's law*](https://en.wikipedia.org/wiki/Moore%27s_law). Wikipedia (Accessed 2022).


### PR DESCRIPTION
The author of _You Can't Spell Trust Without Rust_ and _Learn Rust With Entirely Too Many Linked Lists_ has changed her name — see https://faultlore.com/blah/thesis.pdf and https://github.com/rust-unofficial/too-many-lists/commit/1b0b264d9a64d436aaed361a360cb738be88c4c6